### PR TITLE
Change deb Repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
             - clickhouse-server-base
             - clickhouse-server-common
           sources:
-          - sourceline: 'deb http://repo.yandex.ru/clickhouse/trusty stable main'
+          - sourceline: 'deb http://repo.yandex.ru/clickhouse/deb/stable/ main/'
 
     # OS X BUILDS
     #


### PR DESCRIPTION
Apparently the deb repository has changed causing Travis CI to fail. See Quickstart [at the Clickhouse website](https://clickhouse.yandex/)