### PR TITLE
Properly quoting Identifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ warnings_are_errors: false
 matrix:
   include:
     - os: linux
-      dist: bionic
+      dist: xenial
       sudo: required
       before_install:
         - echo "deb http://repo.yandex.ru/clickhouse/deb/stable/ main/" | sudo tee -a /etc/apt/sources.list

--- a/R/ClickhouseConnection.R
+++ b/R/ClickhouseConnection.R
@@ -182,7 +182,7 @@ setMethod("dbWriteTable", signature(conn = "ClickhouseConnection", name = "chara
       field.types <- append(field.types, "String")
     }
     cat(names(value))
-    fdef <- paste(sapply(names(value),addBackticks, forsql=TRUE), field.types, collapse=', ')
+    fdef <- paste(sapply(names(value),escapeForInternalUse, forsql=TRUE), field.types, collapse=', ')
     ct <- paste0("CREATE TABLE ", qname, " (", fdef, ") ENGINE=", engine)
     cat(paste("R-QUERY:\n",ct,"\n"))
     dbExecute(conn, ct)
@@ -199,7 +199,7 @@ setMethod("dbWriteTable", signature(conn = "ClickhouseConnection", name = "chara
       levels(value[[c]]) <- .Internal(setEncoding(levels(value[[c]]), "UTF-8"))
     }
     print(value)
-    names(value) <- sapply(names(value),addBackticks,forsql=FALSE)
+    names(value) <- sapply(names(value),escapeForInternalUse,forsql=FALSE)
     print(value)
     insert(conn@ptr, qname, value);
   }
@@ -239,7 +239,7 @@ quoteString <- function(x) {
 }
 
 # removes escape characters and then adds backticks for internal handling
-addBackticks <- function(identifier, forsql) {
+escapeForInternalUse <- function(identifier, forsql) {
   print(identifier)
   cat(identifier)
   cat("\n")

--- a/R/ClickhouseConnection.R
+++ b/R/ClickhouseConnection.R
@@ -181,10 +181,8 @@ setMethod("dbWriteTable", signature(conn = "ClickhouseConnection", name = "chara
     } else if (!is.na(rownames.col)) {
       field.types <- append(field.types, "String")
     }
-    cat(names(value))
     fdef <- paste(sapply(names(value),escapeForInternalUse, forsql=TRUE), field.types, collapse=', ')
     ct <- paste0("CREATE TABLE ", qname, " (", fdef, ") ENGINE=", engine)
-    cat(paste("R-QUERY:\n",ct,"\n"))
     dbExecute(conn, ct)
   }
 
@@ -198,9 +196,7 @@ setMethod("dbWriteTable", signature(conn = "ClickhouseConnection", name = "chara
     for (c in names(classes[classes=="factor"])) {
       levels(value[[c]]) <- .Internal(setEncoding(levels(value[[c]]), "UTF-8"))
     }
-    print(value)
     names(value) <- sapply(names(value),escapeForInternalUse,forsql=FALSE)
-    print(value)
     insert(conn@ptr, qname, value);
   }
 
@@ -240,19 +236,10 @@ quoteString <- function(x) {
 
 # removes escape characters and then adds backticks for internal handling
 escapeForInternalUse <- function(identifier, forsql) {
-  print(identifier)
-  cat(identifier)
-  cat("\n")
   if (grepl('^["](.*["])?$', identifier)) {
-    print("HEYYY1")
     identifier <- gsub('^["](.*["])?$', substr(identifier, 2, nchar(identifier) -1), identifier)
   } else if (grepl("^[`](.*[`])?$", identifier)) {
-    print('before')
-    print(identifier)
     identifier <- gsub("^[`](.*[`])?$", substr(identifier, 2, nchar(identifier) -1), identifier)
-    print('after')
-    print(identifier)
-    print("HEYY2")
 
   }
   if (forsql) {

--- a/src/vendor/clickhouse-cpp/clickhouse/client.cpp
+++ b/src/vendor/clickhouse-cpp/clickhouse/client.cpp
@@ -150,7 +150,6 @@ private:
     ServerInfo server_info_;
 };
 
-
 Client::Impl::Impl(const ClientOptions& opts)
     : options_(opts)
     , events_(nullptr)
@@ -199,6 +198,39 @@ void Client::Impl::ExecuteQuery(Query query) {
     }
 }
 
+
+std::string NameToQueryString(const std::string &input)
+{
+    std::string output = "`";
+    const char *c = input.c_str();
+    while (*c) {
+        switch (*c) {
+        // // needs test cases
+        // case '"':
+        //     output.append("\\\""); break;
+        // case '`':
+        //     output.append("\\`"); break;
+        // case '\'':
+        //     output.append("\\'"); break;
+        // case '[':
+        //     output.append("\\["); break;
+        // case ']':
+        //     output.append("\\]"); break;
+        // case '%':
+        //     output.append("\\%"); break;
+        // case '_':
+        //     output.append("\\_"); break;
+        // case '\\':
+        //     output.append("\\\\"); break;
+        default:
+            output.push_back(*c); break;
+        }
+        ++c;
+    }
+    output += "`";
+    return output;
+}
+
 void Client::Impl::Insert(const std::string& table_name, const Block& block) {
     if (options_.ping_before_query) {
         RetryGuard([this]() { Ping(); });
@@ -209,7 +241,8 @@ void Client::Impl::Insert(const std::string& table_name, const Block& block) {
 
     // Enumerate all fields
     for (unsigned int i = 0; i < block.GetColumnCount(); i++) {
-        fields.push_back(block.GetColumnName(i));
+        fields.push_back(NameToQueryString(block.GetColumnName(i)));
+        // fields.push_back(NameToQueryString(block.GetColumnName(i)));
     }
 
     std::stringstream fields_section;
@@ -221,7 +254,7 @@ void Client::Impl::Insert(const std::string& table_name, const Block& block) {
             fields_section << *elem << ",";
         }
     }
-
+    std::cout << "FINAL-QUERY:" << "INSERT INTO " << table_name << " ( " << fields_section.str() << " ) VALUES";
     SendQuery("INSERT INTO " + table_name + " ( " + fields_section.str() + " ) VALUES");
 
     uint64_t server_packet;

--- a/src/vendor/clickhouse-cpp/clickhouse/client.cpp
+++ b/src/vendor/clickhouse-cpp/clickhouse/client.cpp
@@ -197,20 +197,7 @@ void Client::Impl::ExecuteQuery(Query query) {
         ;
     }
 }
-std::string BeforeNameToQueryString(const std::string &input)
-{
-    std::string output = "";
-    const char *c = input.c_str();
-    while (*c) {
-        switch (*c) {
-        default:
-            output.push_back(*c); break;
-        }
-        ++c;
-    }
-    output += "";
-    return output;
-}
+
 
 std::string NameToQueryString(const std::string &input)
 {
@@ -218,6 +205,23 @@ std::string NameToQueryString(const std::string &input)
     const char *c = input.c_str();
     while (*c) {
         switch (*c) {
+        // // needs test cases
+        // case '"':
+        //     output.append("\\\""); break;
+        // case '`':
+        //     output.append("\\`"); break;
+        // case '\'':
+        //     output.append("\\'"); break;
+        // case '[':
+        //     output.append("\\["); break;
+        // case ']':
+        //     output.append("\\]"); break;
+        // case '%':
+        //     output.append("\\%"); break;
+        // case '_':
+        //     output.append("\\_"); break;
+        // case '\\':
+        //     output.append("\\\\"); break;
         default:
             output.push_back(*c); break;
         }
@@ -232,34 +236,12 @@ void Client::Impl::Insert(const std::string& table_name, const Block& block) {
         RetryGuard([this]() { Ping(); });
     }
 
-    std::vector<std::string> fieldss;
-    fieldss.reserve(block.GetColumnCount());
-
-    // Enumerate all fields
-    for (unsigned int i = 0; i < block.GetColumnCount(); i++) {
-        fieldss.push_back(BeforeNameToQueryString(block.GetColumnName(i)));
-        // fields.push_back(NameToQueryString(block.GetColumnName(i)));
-    }
-
-    std::stringstream fieldss_section;
-
-    for (auto elem = fieldss.begin(); elem != fieldss.end(); ++elem) {
-        if (std::distance(elem, fieldss.end()) == 1) {
-            fieldss_section << *elem;
-        } else {
-            fieldss_section << *elem << ",";
-        }
-    }
-    std::cout << "CPP-SEMI-QUERY:\n" << "INSERT INTO " << table_name << " ( " << fieldss_section.str() << " ) VALUES";
-
-
     std::vector<std::string> fields;
     fields.reserve(block.GetColumnCount());
 
     // Enumerate all fields
     for (unsigned int i = 0; i < block.GetColumnCount(); i++) {
         fields.push_back(NameToQueryString(block.GetColumnName(i)));
-        // fields.push_back(NameToQueryString(block.GetColumnName(i)));
     }
 
     std::stringstream fields_section;
@@ -271,8 +253,7 @@ void Client::Impl::Insert(const std::string& table_name, const Block& block) {
             fields_section << *elem << ",";
         }
     }
-    std::cout << "CPP-FINAL-QUERY:\n" << "INSERT INTO " << table_name << " ( " << fields_section.str() << " ) VALUES";
-    SendQuery(" INSERT INTO " + table_name + " ( " + fields_section.str() + " ) VALUES");
+    SendQuery("INSERT INTO " + table_name + " ( " + fields_section.str() + " ) VALUES");
 
     uint64_t server_packet;
     // Receive data packet.

--- a/tests/testthat/test-agg.R
+++ b/tests/testthat/test-agg.R
@@ -1,4 +1,6 @@
 context("aggregation")
+# at suppresses warning pertaining to window function until fixed
+options(warn=-1)
 
 library(DBI, warn.conflicts=F)
 library(dplyr, warn.conflicts=F)

--- a/tests/testthat/test-array.R
+++ b/tests/testthat/test-array.R
@@ -16,3 +16,14 @@ test_that("nullable array columns", {
 test_that("array columns with empty entries", {
   writeReadTest(as.data.frame(data_frame(x=list(c(1,2,3),as.numeric(c()),c(4,5)))))
 })
+
+
+test_that("lucaTest", {
+  writeReadTest(as.data.frame(data.frame(
+    "capitals"=c("Vienna","Washington D.C.", "Paris", "London"),
+    "best sights"=c("Viennese Opera","Lincoln Memorial", "Eiffel Tower", "London Bridge"),
+    "Col with space"=1:4,
+    stringsAsFactors=FALSE,
+    check.names=FALSE
+  )))
+})

--- a/tests/testthat/test-array.R
+++ b/tests/testthat/test-array.R
@@ -18,7 +18,8 @@ test_that("array columns with empty entries", {
 })
 
 
-test_that("lucaTest", {
+# adding Data to CH containing columns with spaces
+test_that("columns with spaces", {
   writeReadTest(as.data.frame(data.frame(
     "capitals"=c("Vienna","Washington D.C.", "Paris", "London"),
     "best sights"=c("Viennese Opera","Lincoln Memorial", "Eiffel Tower", "London Bridge"),
@@ -27,3 +28,28 @@ test_that("lucaTest", {
     check.names=FALSE
   )))
 })
+test_that("columns with spaces quoted with backticks", {
+  writeReadTest(as.data.frame(data.frame(
+    "`capitals`"=c("Vienna","Washington D.C.", "Paris", "London"),
+    "`best sights`"=c("Viennese Opera","Lincoln Memorial", "Eiffel Tower", "London Bridge"),
+    "`Col with space`"=1:4,
+    stringsAsFactors=FALSE,
+    check.names=FALSE
+  )))
+})
+test_that("columns with spaces quoted with DoubleQuotes", {
+  writeReadTest(as.data.frame(data.frame(
+    '"capitals"'=c("Vienna","Washington D.C.", "Paris", "London"),
+    '"best sights"'=c("Viennese Opera","Lincoln Memorial", "Eiffel Tower", "London Bridge"),
+    '"Col with space"'=1:4,
+    stringsAsFactors=FALSE,
+    check.names=FALSE
+  )))
+})
+
+
+
+
+
+
+

--- a/tests/testthat/test-dbplyr-ch.R
+++ b/tests/testthat/test-dbplyr-ch.R
@@ -1,4 +1,5 @@
 context("dbplyr-ch")
+
 # ToDo: make the tests with SQL string comparisons only, since actual DB operations are not necessary
 # just use show_query() and to comparison, organize SQL-Strings in directory...
 # ToDo: fix problem where you have to import directly dplyr::    why suddenly not working anymore?
@@ -22,13 +23,13 @@ tableC <- data.frame(
   "KEY"=c(1,5),
   "C"=c('c1', 'c5')
 )
+
 DBI::dbWriteTable(conn, "tableA", tableA, overwrite=TRUE)
 DBI::dbWriteTable(conn, "tableB", tableB, overwrite=TRUE)
 DBI::dbWriteTable(conn, "tableC", tableC, overwrite=TRUE)
 pointerTableA <- tbl(conn, "tableA")
 pointerTableB <- tbl(conn, "tableB")
 pointerTableC <- tbl(conn, "tableC")
-
 
 
 # Left_JOIN_Variations
@@ -42,6 +43,7 @@ test_that("left_join() with ON-clause between two tables WITHOUT a common column
   expect_equal(data.frame(left_join(pointerTableA, pointerTableC, by = c('ID'='KEY'))), data.frame(ID = c(1, 2), A = c('a1','a2'), C = c('c1','')))
 })
 
+
 # Recreate Problem from Issue #61
 test_that("example form #61", {
   expect_equal(data.frame(pointerTableA  %>% dplyr::select(ID, A) %>% left_join(pointerTableB %>% dplyr::select(ID,B), by = c("ID"))), data.frame(ID = c(1, 2), A = c('a1','a2'), B = c('','b2')))
@@ -53,11 +55,11 @@ test_that("example form #61 with two tables in ON-clause", {
   expect_equal(data.frame(pointerTableA  %>% dplyr::select(ID, A) %>% left_join(pointerTableB %>% dplyr::select(ID,B))), data.frame(ID = c(1, 2), A = c('a1','a2'), B = c('','b2')))
 })
 
+
 # Complex SQL-Generations
 test_that("3 left_joins", {
   expect_equal(data.frame(pointerTableA  %>% dplyr::select(ID, A) %>% left_join(pointerTableB %>% dplyr::select(B,ID)) %>% left_join(left_join(pointerTableA, pointerTableC, by = c('ID'='KEY')))), data.frame(ID = c(1, 2), A = c('a1','a2'), B = c('','b2'), C = c('c1','')))
 })
-
 
 
 # Various_JOINS

--- a/tests/testthat/test-escape.R
+++ b/tests/testthat/test-escape.R
@@ -6,8 +6,7 @@ library(dplyr, warn.conflicts=F)
 
 source("utils.R")
 
-# the following code tests the usage of IDENTIFIERS to mark the boundaries of column names
-# --> for the creation of tables
+# tests if IDENTIFIERS are correctly encoded: creation of tables
 noSpaceDoubleQuotes <- data.frame(
   "capitals"=c("Vienna","Washington D.C.", "Paris", "London"),
   "best_sights"=c("Viennese Opera","Lincoln Memorial", "Eiffel Tower", "London Bridge"),
@@ -18,6 +17,7 @@ noSpaceDoubleQuotes <- data.frame(
 test_that("creating noSpaceColumns IDENTIFIED with doubleQuotes", {
   writeReadTest(as.data.frame(noSpaceDoubleQuotes))
 })
+
 
 # currently failing
 # withGapDoubleQuotes <- data.frame(

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -45,6 +45,7 @@ writeReadTest <- function(input, result = input, types = NULL) {
   #  checks consistency of data before and after ReadWrite
   attr(afterReadWrite, "data.type") <- NULL
   attr(result, "data.type") <- NULL
+  names(result) <- sapply(names(result),escapeForInternalUse,forsql=FALSE)
   expect_equal(afterReadWrite, result)
 
   dbDisconnect(conn)

--- a/tests/testthat/utils.R
+++ b/tests/testthat/utils.R
@@ -45,7 +45,7 @@ writeReadTest <- function(input, result = input, types = NULL) {
   #  checks consistency of data before and after ReadWrite
   attr(afterReadWrite, "data.type") <- NULL
   attr(result, "data.type") <- NULL
-  names(result) <- sapply(names(result),escapeForInternalUse,forsql=FALSE)
+  names(result) <- sapply(names(result),RClickhouse:::escapeForInternalUse,forsql=FALSE)
   expect_equal(afterReadWrite, result)
 
   dbDisconnect(conn)


### PR DESCRIPTION
Thus far identifiers weren't correctly quoted. An examples of problem was issue #58, where one couldn't add column-names which contained spaces. 
@vpanfilov pointed out that that it might be a `clickhouse-cpp` problem: https://github.com/ClickHouse/clickhouse-cpp/issues/30    
In a [pull-request](https://github.com/pakapor/clickhouse-cpp/tree/bugfix-insertSpaceColumn) @pakapor suggested code that might fix the proglem.

After applying @pakapor's code #58 seems to be resolved.