### PR TITLE
Fix `db_connection_describe ()` method consistency

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -1,6 +1,6 @@
 #' @export
 #' @importFrom dbplyr db_connection_describe
-db_connection_describe.ClickhouseConnection <- function(con) {
+db_connection_describe.ClickhouseConnection <- function(con, ...) {
   info <- dbGetInfo(con)
   
   uptime_days <- round(info$uptime/60/60/24, digits = 2)


### PR DESCRIPTION
This came up when checking the revdeps of dbplyr.